### PR TITLE
[nemo-qml-plugin-dbus] Ignore QDBusUnixFileDescriptor values when demarshalling. JB#54169 JOLLA-126

### DIFF
--- a/src/nemo-dbus/dbus.cpp
+++ b/src/nemo-dbus/dbus.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2016 Jolla Ltd
- * Contact: Andrew den Exter <andrew.den.exter@jolla.com>
+ * Copyright (C) 2016 - 2021 Jolla Ltd.
+ * Copyright (C) 2021 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -114,8 +114,8 @@ QVariant demarshallDBusArgument(const QVariant &val, int depth)
         /* Convert QDBusSignature to QString */
         res =  val.value<QDBusSignature>().signature();
     } else if (type == qMetaTypeId<QDBusUnixFileDescriptor>()) {
-        /* Convert QDBusUnixFileDescriptor to int */
-        res =  val.value<QDBusUnixFileDescriptor>().fileDescriptor();
+        /* Ignore, leave it to the receiver to extract the file descriptor */
+        res = val;
     } else if (type == qMetaTypeId<QDBusArgument>()) {
         /* Try to deal with everything QDBusArgument could be ... */
         const QDBusArgument &arg = val.value<QDBusArgument>();

--- a/tests/auto/tst_dbus_interface.qml
+++ b/tests/auto/tst_dbus_interface.qml
@@ -187,7 +187,6 @@ TestCase {
         repr, {type:'g',value:"tussi"},           "repr: signature",             'signature:"tussi"',
         echo, {type:'g',value:"tussi"},           "echo: signature",             "tussi",
         repr, {type:'h',value:2},                 "repr: fd",                    /^fd:[1-9][0-9]*$/,
-        echo, {type:'h',value:2},                 "echo: fd",                    /^[1-9][0-9]*$/,
         repr, {type:'ab',value:[true,false,true]},"repr: array boolean",         'array [ boolean:true boolean:false boolean:true ]',
         echo, {type:'ab',value:[true,false,true]},"echo: array byte",            [true,false,true],
         repr, {type:'ay',value:[1,2,3]},          "repr: array byte",            'array [ byte:1 byte:2 byte:3 ]',


### PR DESCRIPTION
    The value returned by QDBusUnixFileDescriptor::fileDescriptor() is
    invalid once the object is destroyed, so leave it to be handled by
    the caller.
