### PR TITLE
[nemo-qml-plugin-dbus] Port to sailfish-qdoc-template. Contributes to JB#54004

### DIFF
--- a/dbus.pro
+++ b/dbus.pro
@@ -1,14 +1,7 @@
 TEMPLATE = subdirs
-SUBDIRS += src tests
-
-CONFIG += mer-qdoc-template
-MER_QDOC.project = nemo-qml-plugin-dbus
-MER_QDOC.config = doc/nemo-qml-plugin-dbus.qdocconf
-MER_QDOC.style = offline
-MER_QDOC.path = /usr/share/doc/nemo-qml-plugin-dbus
+SUBDIRS += src tests doc
 
 OTHER_FILES += \
-    rpm/nemo-qml-plugin-dbus-qt5.spec \
-    doc/src/index.qdoc
+    rpm/nemo-qml-plugin-dbus-qt5.spec
 
 tests.depends = src

--- a/doc/doc.pro
+++ b/doc/doc.pro
@@ -1,0 +1,11 @@
+TEMPLATE = aux
+
+CONFIG += sailfish-qdoc-template
+
+SAILFISH_QDOC.project = nemo-qml-plugin-dbus
+SAILFISH_QDOC.config = nemo-qml-plugin-dbus.qdocconf
+SAILFISH_QDOC.style = offline
+SAILFISH_QDOC.path = /usr/share/doc/nemo-qml-plugin-dbus
+
+OTHER_FILES += \
+    src/index.qdoc

--- a/doc/nemo-qml-plugin-dbus.qdocconf
+++ b/doc/nemo-qml-plugin-dbus.qdocconf
@@ -2,7 +2,7 @@ project         = Nemo QML Plugin D-Bus
 description     = Nemo QML Plugin D-Bus Reference Documentation
 versionsym      =
 version         = 2.0
-url             = https://github.com/nemomobile/nemo-qml-plugin-dbus
+url             = https://github.com/sailfishos/nemo-qml-plugin-dbus/
 
 sourcedirs += src ../src
 
@@ -26,7 +26,7 @@ qhp.NemoQmlPluginDBus.subprojects.qmltypes.sortPages = true
 
 HTML.footer += \
     "<div class=\"footer\">\n" \
-    "  <p><acronym title=\"Copyright\">&copy;</acronym> 2015 Jolla OY</p>\n" \
+    "  <p><acronym title=\"Copyright\">&copy;</acronym> 2021 Jolla OY</p>\n" \
     "  <p>All other trademarks are property of their respective owners.</p>\n" \
     "  <p>\n" \
     "    This document may be used under the terms of the " \

--- a/rpm/nemo-qml-plugin-dbus-qt5.spec
+++ b/rpm/nemo-qml-plugin-dbus-qt5.spec
@@ -3,12 +3,12 @@ Summary:    DBus plugin for Nemo Mobile
 Version:    2.1.24
 Release:    1
 License:    BSD and LGPLv2
-URL:        https://git.merproject.org/mer-core/nemo-qml-plugin-dbus
+URL:        https://github.com/sailfishos/nemo-qml-plugin-dbus/
 Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5DBus)
-BuildRequires:  mer-qdoc-template
+BuildRequires:  sailfish-qdoc-template
 
 %description
 %{summary}.
@@ -45,12 +45,10 @@ Summary:    DBus plugin documentation
 %qmake5 "VERSION=%{version}"
 make  %{?_smp_mflags}
 make -C tests/dbustestd  %{?_smp_mflags}
-make  %{?_smp_mflags} docs
 
 %install
 %qmake5_install
 make -C tests/dbustestd install ROOT=%{buildroot} VERS=%{version}
-make install_docs INSTALL_ROOT=%{buildroot}
 
 # org.nemomobile.dbus legacy import
 mkdir -p %{buildroot}%{_libdir}/qt5/qml/org/nemomobile/dbus/


### PR DESCRIPTION
Depends on https://github.com/sailfishos/sailfish-qdoc-template/pull/1

@vigejolla @jpetrell @rainemak 