### PR TITLE
[nemo-qml-plugin-dbus] Avoid deprecated API and suspicious log usage. JB#58358

### DIFF
--- a/src/nemo-dbus/connection.cpp
+++ b/src/nemo-dbus/connection.cpp
@@ -78,7 +78,7 @@ bool ConnectionData::getProperty(
 
         return true;
     } else {
-        qCWarning(logs, "DBus error (%s %s org.freedesktop.DBus.Properties.Get): %s",
+        qCWarning(logs(), "DBus error (%s %s org.freedesktop.DBus.Properties.Get): %s",
                   qPrintable(service),
                   qPrintable(path),
                   qPrintable(reply.errorMessage()));
@@ -95,13 +95,13 @@ void ConnectionData::connectToDisconnected()
                 QStringLiteral("Disconnected"),
                 this,
                 SIGNAL(handleDisconnect()))) {
-        qCWarning(logs, "Failed to connection to connection disconnected signal");
+        qCWarning(logs(), "Failed to connection to connection disconnected signal");
     }
 }
 
 void ConnectionData::handleDisconnect()
 {
-    qCDebug(logs, "Disconnected from %s", qPrintable(connection.name()));
+    qCDebug(logs(), "Disconnected from %s", qPrintable(connection.name()));
 
     deletePropertyListeners();
 
@@ -126,7 +126,7 @@ Response *ConnectionData::callMethod(
         const QString &method,
         const QVariantList &arguments)
 {
-    qCDebug(logs, "DBus invocation (%s %s %s.%s)",
+    qCDebug(logs(), "DBus invocation (%s %s %s.%s)",
             qPrintable(service), qPrintable(path), qPrintable(interface), qPrintable(method));
 
     QDBusMessage message = QDBusMessage::createMethodCall(service, path, interface, method);
@@ -155,7 +155,7 @@ QDBusMessage ConnectionData::blockingCallMethod(
         const QString &method,
         const QVariantList &arguments)
 {
-    qCDebug(logs, "DBus invocation (%s %s %s.%s)",
+    qCDebug(logs(), "DBus invocation (%s %s %s.%s)",
             qPrintable(service), qPrintable(path), qPrintable(interface), qPrintable(method));
 
     QDBusMessage message = QDBusMessage::createMethodCall(service, path, interface, method);
@@ -218,14 +218,14 @@ bool Connection::reconnect(const QDBusConnection &connection)
     d->connection = connection;
 
     if (d->connection.isConnected()) {
-        qCDebug(d->logs, "Connected to %s", qPrintable(d->connection.name()));
+        qCDebug(d->logs(), "Connected to %s", qPrintable(d->connection.name()));
 
         d->connectToDisconnected();
         emit d->connected();
 
         return true;
     } else {
-        qCWarning(d->logs, "Connection to %s failed.  %s",
+        qCWarning(d->logs(), "Connection to %s failed.  %s",
                   qPrintable(d->connection.name()), qPrintable(d->connection.lastError().message()));
         return false;
     }
@@ -240,7 +240,7 @@ bool Connection::connectToSignal(
         const char *slot)
 {
     if (!d->connection.connect(service, path, interface,  signal, object, slot)) {
-        qCWarning(d->logs, "Failed to connect to (%s %s %s.%s)",
+        qCWarning(d->logs(), "Failed to connect to (%s %s %s.%s)",
                   qPrintable(service), qPrintable(path), qPrintable(interface), qPrintable(signal));
         return false;
     } else {
@@ -252,7 +252,7 @@ bool Connection::registerObject(
         const QString &path, QObject *object, QDBusConnection::RegisterOptions options)
 {
     if (!d->connection.registerObject(path, object, options)) {
-        qCWarning(d->logs) << "Failed to register object on path" << path << object;
+        qCWarning(d->logs()) << "Failed to register object on path" << path << object;
 
         return false;
     } else {

--- a/src/nemo-dbus/private/propertychanges.cpp
+++ b/src/nemo-dbus/private/propertychanges.cpp
@@ -97,14 +97,14 @@ void PropertyChanges::propertiesChanged(
         const QString &interface, const QVariantMap &changed, const QStringList &invalidated)
 {
     for (auto it = changed.begin(); it != changed.end(); ++it) {
-        qCDebug(m_cache->logs, "DBus property changed (%s %s %s.%s)",
+        qCDebug(m_cache->logs(), "DBus property changed (%s %s %s.%s)",
                 qPrintable(m_service), qPrintable(m_path), qPrintable(interface), qPrintable(it.key()));
 
         emit propertyChanged(interface, it.key(), it.value());
     }
 
     for (auto property : invalidated) {
-        qCDebug(m_cache->logs, "DBus property changed (%s %s %s.%s)",
+        qCDebug(m_cache->logs(), "DBus property changed (%s %s %s.%s)",
                 qPrintable(m_service), qPrintable(m_path), qPrintable(interface), qPrintable(property));
 
         getProperty(interface, property);

--- a/src/nemo-dbus/response.cpp
+++ b/src/nemo-dbus/response.cpp
@@ -50,7 +50,7 @@ void Response::callReturn(const QDBusMessage &message)
 {
     deleteLater();
 
-    qCDebug(logs, "DBus reply (%s %s %s.%s)",
+    qCDebug(logs(), "DBus reply (%s %s %s.%s)",
             qPrintable(message.service()),
             qPrintable(message.path()),
             qPrintable(message.interface()),
@@ -63,7 +63,7 @@ void Response::callError(const QDBusError &error, const QDBusMessage &message)
 {
     deleteLater();
 
-    qCWarning(logs, "DBus error (%s %s %s.%s): %s %s",
+    qCWarning(logs(), "DBus error (%s %s %s.%s): %s %s",
               qPrintable(message.service()),
               qPrintable(message.path()),
               qPrintable(message.interface()),

--- a/src/plugin/declarativedbusinterface.cpp
+++ b/src/plugin/declarativedbusinterface.cpp
@@ -818,13 +818,19 @@ void DeclarativeDBusInterface::pendingCallFinished(QDBusPendingCallWatcher *watc
     if (!callback.isCallable())
         return;
 
+    QJSEngine *engine = qjsEngine(this);
+    if (!engine) {
+        qmlInfo(this) << "Error getting QJSEngine";
+        return;
+    }
+
     QDBusMessage message = reply.reply();
 
     QJSValueList callbackArguments;
 
     QVariantList arguments = message.arguments();
     foreach (QVariant argument, arguments) {
-        callbackArguments << callback.engine()->toScriptValue<QVariant>(NemoDBus::demarshallDBusArgument(argument));
+        callbackArguments << engine->toScriptValue<QVariant>(NemoDBus::demarshallDBusArgument(argument));
     }
 
     QJSValue result = callback.call(callbackArguments);


### PR DESCRIPTION
QJSValue::engine() has been deprecated seemingly the whole Qt5.
The log usage didn't build with Qt6 even though the API is the same.

Alternative to https://github.com/sailfishos/nemo-qml-plugin-dbus/pull/8

@llewelld @Thaodan 