### PR TITLE
[nemo-dbus] Add support for a{sv} type

### DIFF
--- a/src/plugin/declarativedbusinterface.cpp
+++ b/src/plugin/declarativedbusinterface.cpp
@@ -598,6 +598,23 @@ DeclarativeDBusInterface::marshallDBusArgument(QDBusMessage &msg, const QJSValue
             msg << vec;
             return true;
         }
+    } else if (t == "a{sv}") {
+        if (!value.isObject()) {
+            qWarning() << "Invalid value for type specifier:" << t << "v:" << value.toVariant();
+            qmlInfo(this) << "Invalid value for type specifier: " << t << " v: " << value.toVariant();
+            return false;
+        }
+        QVariantMap variantMap;
+        QJSValueIterator it(value);
+        while (it.hasNext()) {
+            it.next();
+            QVariant var = it.value().toVariant();
+            flattenVariantArrayGuessType(var);
+            variantMap.insert(it.name(), var);
+        }
+
+        msg << variantMap;
+        return true;
     }
 
     qWarning() << "DeclarativeDBusInterface::typedCall - Invalid type specifier:" << t;

--- a/tests/auto/tst_dbus_interface.qml
+++ b/tests/auto/tst_dbus_interface.qml
@@ -233,6 +233,8 @@ TestCase {
         echo, {type:'s',value:'COMPLEX3'},        "echo: complex3",              [4,5,6],
         repr, {type:'s',value:'COMPLEX4'},        "repr: complex4",              'struct { byte:255 boolean:true int16:32767 int32:2147483647 int64:9223372036854775807 uint16:65535 uint32:4294967295 uint64:18446744073709551615 double:3.75 string:"string" objpath:"/obj/path" signature:"sointu" }',
         echo, {type:'s',value:'COMPLEX4'},        "echo: complex4",              [255,true,32767,2147483647,9223372036854775807,65535,4294967295,18446744073709551615,3.75,"string","/obj/path","sointu"],
+        repr, {type:'a{sv}',value:{a:1, b:"two"}},"repr: array string-variant",  'array [ key string:"a" val variant int32:1 key string:"b" val variant string:"two" ]',
+        echo, {type:'a{sv}',value:{a:1, b:"two"}},"echo: array string-variant",  {a:1, b:"two"},
     ]
 
     function methodEnd(res) {


### PR DESCRIPTION
So, this adds rudimentary support fro the a{sv} type, which is array of string-variant pairs.
QT, sensibly, maps that to/from QVariantMap.

This was tested with harbour-seaprint-share-plugin calling org.freedesktop.Application.Open on harbour-seaprint from the SharePlugin QML.
(Commits there landing soon-ish, maybe on branch for the former)
It works both with and without content in the a{sv} object.

flattenVariantArrayGuessType looks fishy... but since it is done on plain variants, i do it here too.
I had some issues with it, but those were PEBKAC.

I have no idea how to run the tests, so i haven't done so, nor added any. Hints on that much appreciated.