### PR TITLE
[nemo-dbus] Don't install test .service file as executable. JB#63301

### DIFF
--- a/tests/dbustestd/Makefile
+++ b/tests/dbustestd/Makefile
@@ -106,4 +106,4 @@ install::
 	install -m755 dbustestd $(ROOT)$(PLUGIN_DIR)/bin/
 
 	install -m755 -d $(ROOT)$(DBUS_DIR)/services/
-	install -m755 dbus/org.nemomobile.dbustestd.service $(ROOT)$(DBUS_DIR)/services/
+	install -m644 dbus/org.nemomobile.dbustestd.service $(ROOT)$(DBUS_DIR)/services/


### PR DESCRIPTION
It's a text file.